### PR TITLE
Fix issues with deploying the production version of this VUE app on a server with a relative path.

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -72,7 +72,9 @@ module.exports = {
         loader: 'url-loader',
         options: {
           limit: 10000,
-          name: utils.assetsPath('fonts/[name].[hash:7].[ext]')
+          name: utils.assetsPath('fonts/[name].[hash:7].[ext]'),
+          // workaround for https://github.com/vuejs-templates/webpack/issues/1284
+          publicPath: process.env.NODE_ENV === 'development' ? '/' : '../../'
         }
       }
     ]

--- a/config/index.js
+++ b/config/index.js
@@ -50,8 +50,8 @@ module.exports = {
     // Paths
     assetsRoot: path.resolve(__dirname, '../dist'),
     assetsSubDirectory: 'static',
-    assetsPublicPath: '/',
-
+    assetsPublicPath: process.env.NODE_ENV === 'development' ? '/' : '',
+    publicPath: process.env.NODE_ENV === 'development' ? '/' : '',
     /**
      * Source Maps
      */

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <link rel="shortcut icon" type="image/png" href="/static/CFDE-icon-2.png"/>
+    <link href="static/CFDE-icon-2.png" rel="shortcut icon" type="image/png"/>
     <link rel='stylesheet' href='https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css' type='text/css'/>
     <script src='https://code.jquery.com/jquery-3.2.1.min.js'></script>
     <script src='https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js'></script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,8 +4,9 @@ import Router from 'vue-router'
 Vue.use(Router)
 
 export default new Router({
-  // mode: 'hash',
-  mode: 'history',
+  mode: 'hash',
+  // mode: 'history',
+  publicPath: process.env.NODE_ENV === 'development' ? '/' : '',
   routes: [
     //    {
     //      path: '/usecase1',


### PR DESCRIPTION
These changes were required for me to home this application along with our other components (e.g. `chaise`, `dashboard`) on `app-dev.nih-cfde.org` in a sub-path off of the root: `/gexb/`.